### PR TITLE
running virtual box in headless mode

### DIFF
--- a/setup/linux/packer-linux.json
+++ b/setup/linux/packer-linux.json
@@ -21,6 +21,7 @@
     "iso_checksum_type": "md5",
     "ssh_username": "ubuntu",
     "ssh_password": "ubuntu",
+    "headless": true,
     "http_directory": "preseed",
     "shutdown_command": "sudo shutdown -P now",
     "boot_command": [

--- a/setup/mac/packer-mac.json
+++ b/setup/mac/packer-mac.json
@@ -21,6 +21,7 @@
     "iso_checksum_type": "md5",
     "ssh_username": "ubuntu",
     "ssh_password": "ubuntu",
+    "headless": true,
     "http_directory": "preseed",
     "shutdown_command": "sudo shutdown -P now",
     "boot_command": [


### PR DESCRIPTION
Fixes #24 

This PR should run the virtualbox setup in headless mode. You should no longer see the VirtualBox popup.
