### PR TITLE
Cg feature packer 1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Virtualbox:
 
 Packer:
 
-- [Download zip file for amd64 mac](https://www.packer.io/downloads.html) *Nopte Requires Packer 1.5+
+- [Download zip file for amd64 mac](https://www.packer.io/downloads.html) *Note Requires Packer 0.5+
 - Unzip, rename folder to "packer", and move folder to /usr/local/bin
 - Add /usr/local/bin/packer to $PATH
 - Optionally you can use a package manager to install packer

--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ Virtualbox:
 
 Packer:
 
-- [Download zip file 0.4.1 for amd64 mac](https://dl.bintray.com/mitchellh/packer/#0.4.1_darwin_amd64.zip) *Note CG has only verified cg-init up to 0.4.1
+- [Download zip file for amd64 mac](https://www.packer.io/downloads.html) *Nopte Requires Packer 1.5+
 - Unzip, rename folder to "packer", and move folder to /usr/local/bin
 - Add /usr/local/bin/packer to $PATH
+- Optionally you can use a package manager to install packer
 
 
 To boostrap environment run, change directory to setup/ and run the install.sh script passing the host architecture as an agrument:

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -35,7 +35,7 @@ else
   #do packer install
   echo "Starting packer build at " `date`  
   #PACKER_LOG=1 packer build -only=virtualbox $1/packer-$1.json
-  packer build -only=virtualbox $1/packer-$1.json
+  packer build -only=virtualbox-iso $1/packer-$1.json
   echo "Packer build complete at " `date`
 
   #vagrant init

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -40,7 +40,7 @@ else
 
   #vagrant init
   echo "Starting Vagrant initialization at " `date`
-  vagrant init dev packer_virtualbox_virtualbox.box 
+  vagrant init dev packer_virtualbox-iso_virtualbox.box 
   echo "Vagrant initilization complete at " `date`
 
   #add ssh user

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -23,7 +23,7 @@ else
   if [ -e "packer_virtualbox_virtualbox.box" ]
   then  
   echo "Removing current box"
-  rm packer_virtualbox_virtualbox.box
+  rm packer_virtualbox-iso_virtualbox.box
   fi
  
   if [ -e ".vagrant" ]

--- a/setup/linux/packer-linux.json
+++ b/setup/linux/packer-linux.json
@@ -14,10 +14,10 @@
     "ami_name": "cg-dev-packer-app{{timestamp}}"
   },
   {
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "guest_os_type": "Ubuntu_64",
-    "iso_url": "http://releases.ubuntu.com/precise/ubuntu-12.04.4-server-amd64.iso",
-    "iso_checksum": "e83adb9af4ec0a039e6a5c6e145a34de",
+    "iso_url": "http://releases.ubuntu.com/trusty/ubuntu-14.04.1-server-amd64.iso",
+    "iso_checksum": "ca2531b8cd79ea5b778ede3a524779b9",
     "iso_checksum_type": "md5",
     "ssh_username": "ubuntu",
     "ssh_password": "ubuntu",

--- a/setup/mac/packer-mac.json
+++ b/setup/mac/packer-mac.json
@@ -14,10 +14,10 @@
     "ami_name": "cg-dev-packer-app{{timestamp}}"
   },
   {
-    "type": "virtualbox",
+    "type": "virtualbox-iso",
     "guest_os_type": "Ubuntu_64",
-    "iso_url": "http://releases.ubuntu.com/precise/ubuntu-12.04.4-server-amd64.iso",
-    "iso_checksum": "e83adb9af4ec0a039e6a5c6e145a34de",
+    "iso_url": "http://releases.ubuntu.com/trusty/ubuntu-14.04.1-server-amd64.iso",
+    "iso_checksum": "ca2531b8cd79ea5b778ede3a524779b9",
     "iso_checksum_type": "md5",
     "ssh_username": "ubuntu",
     "ssh_password": "ubuntu",


### PR DESCRIPTION
This PR addresses #27 which allows for use of packer versions 1.5 and up. Packer 1.5 introduced a non backwards compatible change for build types. This PR updates cg-init to with the new type. It also updates to ubuntu 14.04